### PR TITLE
Added I18NUtility

### DIFF
--- a/src/main/java/tests/I18nUtilityTest.java
+++ b/src/main/java/tests/I18nUtilityTest.java
@@ -1,0 +1,75 @@
+package tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import utilities.I18NUtility;
+
+import java.util.MissingResourceException;
+
+class I18nUtilityTest {
+
+    @Test
+    void testGetStringWithValidKey() {
+        Assertions.assertEquals("Hello All!!!", I18NUtility.getString("com.sample.message"));
+    }
+
+    @Test
+    void testGetStringWithInvalidKey() {
+        boolean missingResourceExceptionThrown = false;
+        try {
+            I18NUtility.getString("com.sample.message.invalid");
+        }
+        catch(MissingResourceException e) {
+            missingResourceExceptionThrown = true;
+        }
+        finally {
+            Assertions.assertTrue(missingResourceExceptionThrown);
+        }
+    }
+
+    @Test
+    void testAddValidResourceBundle() {
+        I18NUtility.addResourceBundle("Test1_Resource_Bundle");
+        String value = I18NUtility.getString("test1.message");
+        Assertions.assertEquals("test message 1", value);
+    }
+
+    @Test
+    void testAddMissingResourceBundle() {
+        boolean missingResourceExceptionThrown = false;
+        try {
+            I18NUtility.addResourceBundle("Test1_Resource_Bundle_invalid");
+        }
+        catch (MissingResourceException e) {
+            missingResourceExceptionThrown = true;
+        }
+        Assertions.assertTrue(missingResourceExceptionThrown);
+    }
+
+    @Test
+    void testRemoveResourceBundle() {
+        I18NUtility.addResourceBundle("Test2_Resource_Bundle");
+        I18NUtility.getString("test2.message");
+        I18NUtility.removeResourceBundle("Test2_Resource_Bundle");
+        boolean missingResourceExceptionThrown = false;
+        try {
+            I18NUtility.getString("test2.message");
+        }
+        catch (MissingResourceException e) {
+            missingResourceExceptionThrown = true;
+        }
+        Assertions.assertTrue(missingResourceExceptionThrown);
+    }
+
+    @Test
+    void testRemoveMissingResourceBundle() {
+        boolean missingResourceExceptionThrown = false;
+        try {
+            I18NUtility.removeResourceBundle("Test1_Resource_Bundle_invalid");
+        }
+        catch (MissingResourceException e) {
+            missingResourceExceptionThrown = true;
+        }
+        Assertions.assertTrue(missingResourceExceptionThrown);
+    }
+}

--- a/src/main/java/utilities/I18NUtility.java
+++ b/src/main/java/utilities/I18NUtility.java
@@ -1,0 +1,89 @@
+package utilities;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class I18NUtility {
+
+    private static String language = "en";// TODO: Add to SettingUtility
+    private static String region = "US";// TODO: Add to SettingUtility
+    private static Locale locale = new Locale(language, region);
+    private static Set<String> resourceBundleNames = Collections.synchronizedSet(new HashSet<>());
+    private static Set<ResourceBundle> resourceBundles = Collections.synchronizedSet(new HashSet<>());
+
+    static {
+        resourceBundleNames.add("I18N_Resource_Bundle");
+        buildResourceBundlesSet();
+    }
+
+    /**
+     * Build the ResourceBundle objects from the currently specified resource bundle names in the resourceBundleNames set
+     */
+    private static void buildResourceBundlesSet() {
+        resourceBundles.clear();
+        resourceBundles.addAll(
+                resourceBundleNames.stream()
+                        .map(resourceBundleName -> ResourceBundle.getBundle(resourceBundleName, locale))
+                        .collect(Collectors.toSet())
+        );
+    }
+
+    /**
+     * Retrieves the value corresponding to the key specified.
+     * If multiple resource bundles contain the same key, the first resource
+     * bundle (Decided by the order in which the resource bundle is added) in
+     * which the key is present is used.
+     * @param key The key to retrieve the value for
+     * @return The value corresponding to the key specified
+     */
+    public static String getString(String key) {
+        Optional<String> value = resourceBundles.stream()
+            .map(resourceBundle -> {
+                String tempValue;
+                try {
+                    tempValue = resourceBundle.getString(key);
+                }
+                catch (MissingResourceException e) {
+                    tempValue = null;
+                }
+                return tempValue;
+            })
+            .filter(Objects::nonNull)
+            .findFirst();
+        if(value.isPresent()) {
+            return value.get();
+        }
+        else {
+            throw new MissingResourceException(
+                String.format("Can't find resource for bundle %s", key),
+                I18NUtility.class.getName(),
+                key
+            );
+        }
+    }
+
+    /**
+     * Add a specified resource bundle
+     * @param resourceBundleName Resource bundle to add
+     */
+    public synchronized static void addResourceBundle(String resourceBundleName) {
+        resourceBundleNames.add(resourceBundleName);
+        buildResourceBundlesSet();
+    }
+
+    /**
+     * Remove a specified resource bundle
+     * @param resourceBundleName Resource bundle to remove
+     */
+    public synchronized static void removeResourceBundle(String resourceBundleName) {
+        boolean resourceBundlePresent = resourceBundleNames.remove(resourceBundleName);
+        if(!resourceBundlePresent) {
+            throw new MissingResourceException(
+                    String.format("Can't find resource bundle %s", resourceBundleName),
+                    I18NUtility.class.getName(),
+                    resourceBundleName
+            );
+        }
+        buildResourceBundlesSet();
+    }
+}

--- a/src/main/resources/I18N_Resource_Bundle_en_US.properties
+++ b/src/main/resources/I18N_Resource_Bundle_en_US.properties
@@ -1,0 +1,1 @@
+com.sample.message=Hello All!!!

--- a/src/main/resources/Test1_Resource_Bundle_en_US.properties
+++ b/src/main/resources/Test1_Resource_Bundle_en_US.properties
@@ -1,0 +1,1 @@
+test1.message=test message 1

--- a/src/main/resources/Test2_Resource_Bundle_en_US.properties
+++ b/src/main/resources/Test2_Resource_Bundle_en_US.properties
@@ -1,0 +1,1 @@
+test2.message=test message 2


### PR DESCRIPTION
Closes #17
This utility is used to retrieve messages relevant to a specific locale.
The requirements are as follows:

    Retrieve the message corresponding to the key.
    Add documentation comments.
    Internationalize messages.
    Convert all print statements to log statements.
    Add test coverage for all requirements.