### PR TITLE
Transfer all properties in UtilityResources to property files

### DIFF
--- a/src/main/resources/icing.properties
+++ b/src/main/resources/icing.properties
@@ -42,3 +42,7 @@ utilities.I18NUtility.resourcebundle.default=I18N_Resource_Bundle
 utilities.ShellUtility.linux.which=which %s
 utilities.ShellUtility.windows.where=where %s
 utilities.ShellUtility.timeout=5
+utilities.SShUtility.ciphers=
+utilities.SShUtility.execution.timeout=5
+utilities.SShUtility.login.retries=5
+utilities.SShUtility.login.timeout=5


### PR DESCRIPTION
Closes #28
The configuration values stored in the UtilityResources should
be in a .properties file and access to these values should be
through the PropertyUtility.