### PR TITLE
Transfer all properties in TestResources to a property file

### DIFF
--- a/src/main/java/tests/TestResources.java
+++ b/src/main/java/tests/TestResources.java
@@ -1,9 +1,0 @@
-package tests;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-public class TestResources
-{
-    public static final Path TMP_PATH = Paths.get("/tmp");
-}

--- a/src/main/resources/icing.properties
+++ b/src/main/resources/icing.properties
@@ -1,5 +1,6 @@
 common.language=en
 common.region=US
+common.dir.temp=/tmp
 
 regex.email.address=
 


### PR DESCRIPTION
Closes #31
The configuration values stored in the TestResources should be in a
.properties file and access to these values should be through the
PropertyUtility.