### PR TITLE
Add getFormattedString() to I18NUtility

### DIFF
--- a/src/main/java/tests/FileUtilityTest.java
+++ b/src/main/java/tests/FileUtilityTest.java
@@ -1,5 +1,7 @@
 package tests;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import utilities.FileUtility;
@@ -14,6 +16,7 @@ import java.util.stream.IntStream;
 
 public class FileUtilityTest {
 
+    private Logger logger = LogManager.getLogger(FileUtilityTest.class);
     final Path testBedPath;
 
     public FileUtilityTest() {
@@ -24,7 +27,7 @@ public class FileUtilityTest {
         try {
             Files.createDirectory(testBedPath);
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error(e);
         }
         // Create 2 folders with a txt file in each with the same name of the folder - folders1 to folders2
         // Create 2 folders with a txt file in each with the same name of the folder - folder1 to folder2
@@ -37,7 +40,7 @@ public class FileUtilityTest {
                                         Files.createDirectory(testBedPath.resolve(baseName+i));
                                         Files.createFile(testBedPath.resolve(baseName+i).resolve(baseName+i+".txt"));
                                     } catch (IOException e) {
-                                        e.printStackTrace();
+                                        logger.error(e);
                                     }
                                 })
                 );
@@ -49,7 +52,7 @@ public class FileUtilityTest {
                         Files.createDirectory(testBedPath.resolve("fold"+i));
                         Files.createFile(testBedPath.resolve("fold"+i).resolve("fold"+i+".txt"));
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        logger.error(e);
                     }
                 });
     }
@@ -59,7 +62,7 @@ public class FileUtilityTest {
             Runtime.getRuntime()
                     .exec(String.format("rm -rf %s", testBedPath.toString()));
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error(e);
         }
     }
 
@@ -86,7 +89,7 @@ public class FileUtilityTest {
                     .collect(Collectors.toList());
             Assertions.assertEquals(0, folderPaths.size());
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error(e);
         }
         finally {
             clearTestBed();
@@ -103,7 +106,7 @@ public class FileUtilityTest {
             FileUtility.deleteRecursively(path);
             folderDeleted = !Files.exists(path);
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error(e);
         }
         finally {
             clearTestBed();
@@ -147,7 +150,7 @@ public class FileUtilityTest {
             }
         }
         catch(Exception e) {
-            e.printStackTrace();
+            logger.error(e);
         }
         finally {
             // Cleanup files
@@ -224,7 +227,7 @@ public class FileUtilityTest {
         } catch (AccessDeniedException e) {
             actualResult = Boolean.TRUE;
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error(e);
         } finally {
             Set<PosixFilePermission> permissions = new HashSet<>();
             permissions.add(PosixFilePermission.OWNER_READ);

--- a/src/main/java/tests/I18nUtilityTest.java
+++ b/src/main/java/tests/I18nUtilityTest.java
@@ -4,20 +4,57 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import utilities.I18NUtility;
 
+import java.util.IllegalFormatConversionException;
 import java.util.MissingResourceException;
 
 class I18nUtilityTest {
 
     @Test
-    void testGetStringWithValidKey() {
+    void testGetNonFormattedStringWithValidKey() {
         Assertions.assertEquals("Hello All!!!", I18NUtility.getString("com.sample.message"));
+    }
+
+    @Test
+    void testGetFormattedStringWithValidKeyAndValidValues() {
+        Assertions.assertEquals("Hello value1!!!", I18NUtility.getFormattedString("com.sample.formattedmessage", "value1"));
+    }
+
+    @Test
+    void testGetFormattedStringWithValidKeyAndInvalidValues() {
+        boolean illegalFormatConversionExceptionThrown = false;
+        try {
+            I18NUtility.getFormattedString("com.sample.formattedmessage1", "value1");
+        }
+        catch(IllegalFormatConversionException e) {
+            illegalFormatConversionExceptionThrown = true;
+        }
+        Assertions.assertTrue(illegalFormatConversionExceptionThrown);
+    }
+
+    @Test
+    void testGetNonFormattedStringWithValidKeyAndValues() {
+        Assertions.assertEquals("Hello All!!!", I18NUtility.getFormattedString("com.sample.message", "value1"));
     }
 
     @Test
     void testGetStringWithInvalidKey() {
         boolean missingResourceExceptionThrown = false;
         try {
-            I18NUtility.getString("com.sample.message.invalid");
+            I18NUtility .getString("com.sample.message.invalid");
+        }
+        catch(MissingResourceException e) {
+            missingResourceExceptionThrown = true;
+        }
+        finally {
+            Assertions.assertTrue(missingResourceExceptionThrown);
+        }
+    }
+
+    @Test
+    void testGetStringWithInvalidKeyAndValues() {
+        boolean missingResourceExceptionThrown = false;
+        try {
+            Assertions.assertEquals("Hello value1!!!", I18NUtility.getFormattedString("com.sample.formattedmessageinvalid", "value1"));
         }
         catch(MissingResourceException e) {
             missingResourceExceptionThrown = true;

--- a/src/main/java/utilities/FileUtility.java
+++ b/src/main/java/utilities/FileUtility.java
@@ -1,5 +1,8 @@
 package utilities;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -15,6 +18,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public class FileUtility {
+
+    private static Logger logger = LogManager.getLogger(FileUtility.class);
 
     /**
      * Creates a specific number of folders with the specified name and prefix/suffix
@@ -33,7 +38,7 @@ public class FileUtility {
                             try {
                                 Files.createDirectories(folderPath);
                             } catch (IOException e) {
-                                e.printStackTrace();
+                                logger.error(e);
                             }
                         }
                 );
@@ -59,13 +64,13 @@ public class FileUtility {
                             try {
                                 Files.setPosixFilePermissions(node, permissions);
                             } catch (IOException e) {
-                                e.printStackTrace();
+                                logger.error(e);
                             }
                         });
             else
                 Files.setPosixFilePermissions(path, permissions);
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error(e);
         }
     }
 
@@ -107,7 +112,7 @@ public class FileUtility {
         try {
             contents = searchTree ? Files.walk(path) : Files.list(path);
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error(e);
         }
         if (Files.isDirectory(path)) {
             matchList.addAll(
@@ -147,7 +152,7 @@ public class FileUtility {
 
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error(e);
         }
     }
 
@@ -205,7 +210,7 @@ public class FileUtility {
                     try {
                         Files.setAttribute(content, attribute.name(), attribute.value());
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        logger.error(e);
                     }
                 });
     }

--- a/src/main/java/utilities/I18NUtility.java
+++ b/src/main/java/utilities/I18NUtility.java
@@ -1,36 +1,25 @@
 package utilities;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class I18NUtility {
 
+    private static Logger logger = LogManager.getLogger(I18NUtility.class);
     private static String language = PropertyUtility.getProperty("common.language");
     private static String region = PropertyUtility.getProperty("common.region");
     private static Locale locale = new Locale(language, region);
-    private static Set<String> resourceBundleNames = Collections.synchronizedSet(new HashSet<>());
-    private static Set<ResourceBundle> resourceBundles = Collections.synchronizedSet(new HashSet<>());
+    private static Map<String, ResourceBundle> resourceBundles = Collections.synchronizedMap(new HashMap<>());
 
     static {
         String defaultResourceBundleName = PropertyUtility.getProperty("utilities.I18NUtility.resourcebundle.default");
-        resourceBundleNames.add(defaultResourceBundleName);
-        buildResourceBundlesSet();
+        addResourceBundle(defaultResourceBundleName);
     }
 
     /**
-     * Build the ResourceBundle objects from the currently specified resource bundle names in the resourceBundleNames set
-     */
-    private static void buildResourceBundlesSet() {
-        resourceBundles.clear();
-        resourceBundles.addAll(
-                resourceBundleNames.stream()
-                        .map(resourceBundleName -> ResourceBundle.getBundle(resourceBundleName, locale))
-                        .collect(Collectors.toSet())
-        );
-    }
-
-    /**
-     * Retrieves the value corresponding to the key specified.
+     * Retrieves the message string corresponding to the key specified.
      * If multiple resource bundles contain the same key, the first resource
      * bundle (Decided by the order in which the resource bundle is added) in
      * which the key is present is used.
@@ -38,24 +27,30 @@ public class I18NUtility {
      * @return The value corresponding to the key specified
      */
     public static String getString(String key) {
-        Optional<String> value = resourceBundles.stream()
-            .map(resourceBundle -> {
-                String tempValue;
-                try {
-                    tempValue = resourceBundle.getString(key);
-                }
-                catch (MissingResourceException e) {
-                    tempValue = null;
-                }
-                return tempValue;
-            })
-            .filter(Objects::nonNull)
-            .findFirst();
+        Optional<String> value = resourceBundles.values()
+                .stream()
+                .map(resourceBundle -> {
+                    String tempValue;
+                    try {
+                        // Cannot internationalize as calls to getString()/getFormattedString() will cause an infinite recursion
+                        logger.debug("Resource bundle " + resourceBundle.getBaseBundleName() + " contains property - " + key);
+                        tempValue = resourceBundle.getString(key);
+                    }
+                    catch (MissingResourceException e) {
+                        // Cannot internationalize as calls to getString()/getFormattedString() will cause an infinite recursion
+                        logger.debug("Resource bundle " + resourceBundle.getBaseBundleName() + " does not contain property - " + key);
+                        tempValue = null;
+                    }
+                    return tempValue;
+                })
+                .filter(Objects::nonNull)
+                .findFirst();
         if(value.isPresent()) {
             return value.get();
         }
         else {
             throw new MissingResourceException(
+                // Cannot internationalize as calls to getString()/getFormattedString() will cause an infinite recursion
                 String.format("Can't find resource for bundle %s", key),
                 I18NUtility.class.getName(),
                 key
@@ -64,18 +59,32 @@ public class I18NUtility {
     }
 
     /**
+     * Retrieves the message string corresponding to the key specified with the
+     * provided values inserted.
+     * If multiple resource bundles contain the same key, the first resource
+     * bundle (Decided by the order in which the resource bundle is added) in
+     * which the key is present is used.
+     * @param key The key to retrieve the value for
+     * @return The value corresponding to the key specified
+     */
+    public static String getFormattedString(String key, Object... values) {
+        // Cannot internationalize as calls to getFormattedString() will cause an infinite recursion
+        logger.debug("Retrieving property " + key + " with the following format values -  " + Arrays.toString(values));
+        return String.format(
+                getString(key),
+                values
+        );
+    }
+
+    /**
      * Add a specified resource bundle
      * @param resourceBundleName Resource bundle to add
      */
     public synchronized static void addResourceBundle(String resourceBundleName) {
-        resourceBundleNames.add(resourceBundleName);
-        try {
-            buildResourceBundlesSet();
-        }
-        catch (MissingResourceException e) {
-            resourceBundleNames.remove(resourceBundleName);
-            throw e;
-        }
+        // Cannot internationalize as the reuqired I18N string cannot be found without adding the relevant resource bundle
+        logger.debug("Adding resource bundle - " + resourceBundleName);
+        ResourceBundle resourceBundle = ResourceBundle.getBundle(resourceBundleName, locale);
+        resourceBundles.put(resourceBundleName, resourceBundle);
     }
 
     /**
@@ -83,14 +92,14 @@ public class I18NUtility {
      * @param resourceBundleName Resource bundle to remove
      */
     public synchronized static void removeResourceBundle(String resourceBundleName) {
-        boolean resourceBundlePresent = resourceBundleNames.remove(resourceBundleName);
-        if(!resourceBundlePresent) {
+        // Cannot internationalize as the reuqired I18N string cannot be found without adding the relevant resource bundle        logger.debug("Removing resource bundle - " + resourceBundleName);
+        ResourceBundle removedResourceBundle = resourceBundles.remove(resourceBundleName);
+        if(removedResourceBundle == null) {
             throw new MissingResourceException(
                     String.format("Can't find resource bundle %s", resourceBundleName),
                     I18NUtility.class.getName(),
                     resourceBundleName
             );
         }
-        buildResourceBundlesSet();
     }
 }

--- a/src/main/java/utilities/PropertyUtility.java
+++ b/src/main/java/utilities/PropertyUtility.java
@@ -1,5 +1,8 @@
 package utilities;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -9,6 +12,7 @@ import java.util.stream.Collectors;
 
 public class PropertyUtility {
 
+    private static Logger logger = LogManager.getLogger(PropertyUtility.class);
     private static Set<String> propertyFileNames = Collections.synchronizedSet(new HashSet<>());
     private static Set<Properties> propertyFiles = Collections.synchronizedSet(new HashSet<>());
 
@@ -29,7 +33,7 @@ public class PropertyUtility {
                             try {
                                 propertyFile.load(Files.newInputStream(Paths.get(String.valueOf(propertyFileName))));
                             } catch (IOException e) {
-                                e.printStackTrace();
+                                logger.error(e);
                             }
                             return propertyFile;
                         })

--- a/src/main/java/utilities/ShellUtility.java
+++ b/src/main/java/utilities/ShellUtility.java
@@ -1,5 +1,8 @@
 package utilities;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -31,6 +34,7 @@ import java.util.concurrent.TimeoutException;
 
 public class ShellUtility {
 
+    private static Logger logger = LogManager.getLogger(ShellUtility.class);
     private static OS os = OS.getOs();
     private static HashMap<TypeOfShell, Path> shells = new HashMap<>();
 
@@ -57,7 +61,7 @@ public class ShellUtility {
                     shells.put(typeOfShell, Paths.get(response.getOutput(TypeOfOutput.STDOUT).trim()));
                 }
             } catch (IOException | InterruptedException | OsNotFoundException | TimeoutException e) {
-                e.printStackTrace();
+                logger.error(e);
             }
         }
     }
@@ -82,8 +86,8 @@ public class ShellUtility {
         }
 
         public String toString() {
-            return String.format(
-                    I18NUtility.getString("exception.ShellNotFoundException"),
+            return I18NUtility.getFormattedString(
+                    "exception.ShellNotFoundException",
                     typeOfShell
             );
         }
@@ -99,8 +103,8 @@ public class ShellUtility {
         }
 
         public String toString() {
-            return String.format(
-                    I18NUtility.getString("exception.OsNotFoundException"),
+            return I18NUtility.getFormattedString(
+                    "exception.OsNotFoundException",
                     os
             );
         }
@@ -196,20 +200,20 @@ public class ShellUtility {
      */
     public static synchronized Response executeCommand(String command, Duration timeOutDuration) throws IOException, InterruptedException, TimeoutException {
         Objects.requireNonNull(command,
-                String.format(
-                        I18NUtility.getString("input.validation.nonnull"),
+                I18NUtility.getFormattedString(
+                        "input.validation.nonnull",
                         "Command"
                 )
         );
         Objects.requireNonNull(timeOutDuration,
-                String.format(
-                        I18NUtility.getString("input.validation.nonnull"),
+                I18NUtility.getFormattedString(
+                        "input.validation.nonnull",
                         "Duration"
                 )
         );
         System.out.println(
-                String.format(
-                        I18NUtility.getString("utilities.ShellUtility.executing"),
+                I18NUtility.getFormattedString(
+                        "utilities.ShellUtility.executing",
                         command
                 )
         );
@@ -224,8 +228,7 @@ public class ShellUtility {
         if (timedOut) {
             executionDuration = Duration.between(executionStartTimestamp, ZonedDateTime.now()).getSeconds();
             throw new TimeoutException(
-                    String.format(
-                            I18NUtility.getString("exception.TimeoutException"),
+                    I18NUtility.getFormattedString("exception.TimeoutException",
                             command,
                             executionDuration,
                             timeOutDuration.getSeconds()
@@ -266,20 +269,20 @@ public class ShellUtility {
      */
     public static Response executeCommand(Command command, TypeOfShell typeOfShell, Duration timeOutDuration) throws IOException, InterruptedException, ShellNotFoundException, TimeoutException {
         Objects.requireNonNull(command,
-                String.format(
-                        I18NUtility.getString("input.validation.nonnull"),
+                I18NUtility.getFormattedString(
+                        "input.validation.nonnull",
                         "Command"
                 )
         );
         Objects.requireNonNull(typeOfShell,
-                String.format(
-                        I18NUtility.getString("input.validation.nonnull"),
+                I18NUtility.getFormattedString(
+                        "input.validation.nonnull",
                         "TypeOfShell"
                 )
         );
         Objects.requireNonNull(timeOutDuration,
-                String.format(
-                        I18NUtility.getString("input.validation.nonnull"),
+                I18NUtility.getFormattedString(
+                        "input.validation.nonnull",
                         "Duration"
                 )
         );

--- a/src/main/java/utilities/StreamUtility.java
+++ b/src/main/java/utilities/StreamUtility.java
@@ -1,5 +1,8 @@
 package utilities;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,6 +17,8 @@ import java.io.InputStreamReader;
  */
 public class StreamUtility {
 
+    private static Logger logger = LogManager.getLogger(StreamUtility.class);
+
     /**
      * Extracts the information from a given InputStream as a string.
      * @param inputStream The InputStream to parse.
@@ -26,8 +31,9 @@ public class StreamUtility {
                 result = bufferedReader.lines()
                         .reduce("", (x,y) -> x + "\n" + y)
                         .trim();
-        } catch (IOException e) {
-            e.printStackTrace();
+        }
+        catch (IOException e) {
+            logger.error(e);
         }
         return result;
     }

--- a/src/main/resources/I18N_Resource_Bundle_en_US.properties
+++ b/src/main/resources/I18N_Resource_Bundle_en_US.properties
@@ -1,7 +1,13 @@
 com.sample.message=Hello All!!!
+com.sample.formattedmessage=Hello %s!!!
+com.sample.formattedmessage1=Hello %d!!!
 input.validation.nonnull=%s object cannot be null.
 exception.OsNotFoundException=OS not found - %s
 exception.ShellNotFoundException=Shell not found - %s
 exception.TimeoutException=Shell command '%s' timed out ( %ds >= %ds)
+utilities.I18NUtility.property.found=Resource bundle %s contains property %s
+utilities.I18NUtility.property.missing=Resource bundle %s does not contain property %s
+utilities.I18NUtility.resourcebundle.add=Adding resource bundle - %s
+utilities.I18NUtility.resourcebundle.remove=Removing resource bundle - %s
 utilities.ShellUtility.execute=%s -c "%s"
 utilities.ShellUtility.executing=Executing - %s


### PR DESCRIPTION
Closes #38
The I18NUtility::getFormattedString() call takes in parameters that need to be inserted into the format string.

    String.format(
    I18NUtility.getString("utilities.PropertUtility.properties.missing"),
    propertyFileName
    )

    will be replaced by

    I18NUtility.getFormattedString("utilities.PropertUtility.properties.missing", propertyFileName)

Ensured that all utilities are logging strings using the approach mentioned above instead of System.out.print/println or printStackTrace().