### PR TITLE
Fix unit test failure: FileUtilityTest :: testSetPermissions() and testDeleteRecursively()

### DIFF
--- a/src/main/java/utilities/FileUtility.java
+++ b/src/main/java/utilities/FileUtility.java
@@ -57,7 +57,7 @@ public class FileUtility {
      */
     public static void setPermissions(Path path, Set<PosixFilePermission> permissions, boolean setRecursively) {
         try {
-            if (setRecursively)
+            if (setRecursively) {
                 Files.walk(path)
                         .parallel()
                         .forEach(node -> {
@@ -67,6 +67,7 @@ public class FileUtility {
                                 logger.error(e);
                             }
                         });
+            }
             else
                 Files.setPosixFilePermissions(path, permissions);
         } catch (IOException e) {

--- a/src/test/java/FileUtilityTest.java
+++ b/src/test/java/FileUtilityTest.java
@@ -1,5 +1,3 @@
-package tests;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -214,14 +212,14 @@ class FileUtilityTest {
     }
 
     @Test
-    public void testSetPermissions() {
+    public void testSetPermissions() throws IOException {
         createTestBed();
         Path folderPath = testBedPath.resolve("folder1");
         Path filePath = folderPath.resolve("1.txt");
         boolean actualResult = Boolean.FALSE;
         try {
-            Set<PosixFilePermission> permissions = new HashSet<>();
-            permissions.add(PosixFilePermission.OWNER_READ);
+            Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(folderPath);
+            permissions.remove(PosixFilePermission.OWNER_WRITE);
             FileUtility.setPermissions(folderPath, permissions, false);
             Files.createFile(filePath);
         } catch (AccessDeniedException e) {
@@ -229,8 +227,7 @@ class FileUtilityTest {
         } catch (IOException e) {
             logger.error(e);
         } finally {
-            Set<PosixFilePermission> permissions = new HashSet<>();
-            permissions.add(PosixFilePermission.OWNER_READ);
+            Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(folderPath);
             permissions.add(PosixFilePermission.OWNER_WRITE);
             FileUtility.setPermissions(folderPath, permissions, false);
 


### PR DESCRIPTION
Closes #45 & #46
The issue was that, when we set POSIX permissions using the Files class,
it takes it as the whole setting and does not apply it as a diff.
So, we need to pass the whole permission state we want to set the
file/folder permission to.