### PR TITLE
Set default console log level to INFO

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="utilities" level="debug" additivity="false">
+        <Logger name="utilities" level="info" additivity="false">
             <AppenderRef ref="Console"/>
         </Logger>
         <Root level="error">


### PR DESCRIPTION
Closes #48
As of now the log level to console is debug, which ends up
spewing more info than needed while running the unit tests.
The default level can be set to INFO.