### PR TITLE
Add functionality to generate regexps that match any positive number …

### DIFF
--- a/src/main/java/datastructures/tree/AVLTree.java
+++ b/src/main/java/datastructures/tree/AVLTree.java
@@ -3,7 +3,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import misc.Comparison;
-import misc.TypeIndpependentOperations;
+import misc.TypeIndependentOperations;
 public class AVLTree<T extends Comparable<T>> extends BinarySearchTree<T>{
 
 	List<T> sorted_node_values;
@@ -87,10 +87,10 @@ public class AVLTree<T extends Comparable<T>> extends BinarySearchTree<T>{
 	}*/
 	public int getInsertionIndex(T value) {
 		for(int i=0;i<sorted_node_values.size();i++) {
-			if(TypeIndpependentOperations.compare(sorted_node_values.get(i),value) == Comparison.EQUAL) {
+			if(TypeIndependentOperations.compare(sorted_node_values.get(i),value) == Comparison.EQUAL) {
 				return -1;
 			}
-			if(TypeIndpependentOperations.compare(sorted_node_values.get(i),value) == Comparison.GREATER) {
+			if(TypeIndependentOperations.compare(sorted_node_values.get(i),value) == Comparison.GREATER) {
 				return i;
 			}
 		}
@@ -99,7 +99,7 @@ public class AVLTree<T extends Comparable<T>> extends BinarySearchTree<T>{
 	
 	public int find(T value) {
 		for(int i=0;i<sorted_node_values.size();i++) {
-			if(TypeIndpependentOperations.compare(sorted_node_values.get(i),value) == Comparison.EQUAL) {
+			if(TypeIndependentOperations.compare(sorted_node_values.get(i),value) == Comparison.EQUAL) {
 				return i;
 			}
 		}

--- a/src/main/java/datastructures/tree/BinarySearchTree.java
+++ b/src/main/java/datastructures/tree/BinarySearchTree.java
@@ -16,14 +16,14 @@ public class BinarySearchTree<T extends Comparable<T>> extends BinaryTree<T> {
 		if(value.equals(child_value))
 			System.err.println("Value already present in BST");
 		else {
-			if(TypeIndpependentOperations.compare(child_value, value) == Comparison.LESSER) {
+			if(TypeIndependentOperations.compare(child_value, value) == Comparison.LESSER) {
 				if(children[0]==null) {
 					children[0] = new BinarySearchTree<T>(child_value);
 				}
 				else
 					children[0].addChildNode(child_value); //Add to LEFT
 			}
-			else if(TypeIndpependentOperations.compare(child_value, value) == Comparison.GREATER) {
+			else if(TypeIndependentOperations.compare(child_value, value) == Comparison.GREATER) {
 				if(children[1]==null) {
 					children[1] = new BinarySearchTree<T>(child_value);
 				}
@@ -34,7 +34,7 @@ public class BinarySearchTree<T extends Comparable<T>> extends BinaryTree<T> {
 	}
 	public void delete(T node_value) {  
 		
-		if(TypeIndpependentOperations.compare(value,node_value) == Comparison.EQUAL) {
+		if(TypeIndependentOperations.compare(value,node_value) == Comparison.EQUAL) {
 			if(children[0]!=null) {
 				value = children[0].max();
 				if(children[0].children[1]!=null || children[0].children[0]!=null)

--- a/src/main/java/datastructures/tree/Tree.java
+++ b/src/main/java/datastructures/tree/Tree.java
@@ -5,15 +5,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 public class Tree<T extends Comparable<T>> {
 	T value;
 	Tree<T>[] children;
 	int children_count,current_index;
 	boolean tree_changed;
-	TypeIndpependentOperations<T> TIO;
+	TypeIndependentOperations<T> TIO;
 	int tree_nodes_count;
 	Tree(T value, int children_count) {
 		this.value = value;
@@ -21,7 +19,7 @@ public class Tree<T extends Comparable<T>> {
 		for(int i=0;i<children_count;i++)
 			children[i]=null;
 		current_index = 0;
-		TIO = new TypeIndpependentOperations<T>();
+		TIO = new TypeIndependentOperations<T>();
 		this.children_count = children_count;
 		tree_changed=false;
 		tree_nodes_count=1;

--- a/src/main/java/misc/Comparison.java
+++ b/src/main/java/misc/Comparison.java
@@ -1,10 +1,39 @@
 package misc;
 
 
+import java.math.BigDecimal;
+
 public enum Comparison {
 	EQUAL,
 	UNEQUAL,
 	GREATER,
+	GREATER_THAN_EQUAL,
 	LESSER,
-	NA
+	LESSER_THAN_EQUAL;
+
+	/**
+	 * Evaluates the current comparison operation against the specified numbers.
+	 * @param number1 Number to compare on the left hand side of the operator.
+	 * @param number2 Number to compare on the right hand side of the operator.
+	 * @return Result of the comparison operation.
+	 */
+	public boolean evaluateComparison(Number number1, Number number2) {
+		boolean result = false;
+		BigDecimal num1 = new BigDecimal(number1.doubleValue());
+		BigDecimal num2 = new BigDecimal(number2.doubleValue());
+
+		switch(this) {
+			case EQUAL:
+			case GREATER_THAN_EQUAL:
+			case LESSER_THAN_EQUAL:
+				result = (num1.compareTo(num2) == 0);
+		}
+		if(this == Comparison.LESSER || this == Comparison.LESSER_THAN_EQUAL) {
+			result |= (num1.compareTo(num2) < 0);
+		}
+		else if(this == Comparison.GREATER || this == Comparison.GREATER_THAN_EQUAL) {
+			result |= (num1.compareTo(num2) > 0);
+		}
+		return result;
+	}
 }

--- a/src/main/java/misc/TypeIndependentOperations.java
+++ b/src/main/java/misc/TypeIndependentOperations.java
@@ -1,6 +1,6 @@
 package misc;
 import datastructures.tree.NodeTemplate;
-public class TypeIndpependentOperations<T> {
+public class TypeIndependentOperations<T> {
 	public static <T> Comparison compare(T value1,T value2) {
 		if(value1.getClass().equals(Byte.class)
 		 ||value1.getClass().equals(Short.class)
@@ -25,7 +25,7 @@ public class TypeIndpependentOperations<T> {
 		else if(value1 instanceof NodeTemplate && value2 instanceof NodeTemplate)
 			return ((NodeTemplate)value1).compare((NodeTemplate)value1,(NodeTemplate)value2);
 		else
-			return Comparison.NA;
+			throw new UnsupportedOperationException();
 	}
 }
 


### PR DESCRIPTION
…that is lesser than a specified number

Closes #55.
Eg: For identifying numbers < 1125

Regular Regex
    < 1125 maps to '1[0-0]\d{2}'
    OR '11([0-1]\d)'
    OR '112[0-4]'
    OR '^\d$'
    OR '^\d{2}$'
    OR '^\d{3}$'

SQL Regex
    < 1125 maps to '1[0-0][0-9][0-9]'
    OR '11([0-1][0-9])'
    OR '112[0-4]'
    OR '^[0-9]$'
    OR '^[0-9][0-9]$'
    OR '^[0-9][0-9][0-9]$'