### PR TITLE
Added date based versioning and config to deploy to GitHub in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>JavaUtil</groupId>
-    <artifactId>utilities</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <groupId>org.java</groupId>
+    <artifactId>icing</artifactId>
+    <version>2020.09.21</version>
 
     <properties>
         <maven.compiler.target>14</maven.compiler.target>
@@ -25,6 +25,14 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>java-icing MVN package deployment</name>
+            <url>https://maven.pkg.github.com/the-c0d3br34k3r/java-icing</url>
+        </repository>
+    </distributionManagement>
 
     <dependencies>
 


### PR DESCRIPTION
Closes #88.
Started using date based verioning.
Now "mvn deploy" will deploy the mvn package to GitHub and it can
be used as a maven dependency for other projects.